### PR TITLE
feat(issue-78): Clean up deprecated MAW infrastructure

### DIFF
--- a/ψ-logs/2025-12/08/17.37_nnn-workflow-always-provide-links.md
+++ b/ψ-logs/2025-12/08/17.37_nnn-workflow-always-provide-links.md
@@ -1,0 +1,34 @@
+# nnn Workflow: Always Provide Links
+
+**Time**: 17:37 GMT+7
+
+## What We Learned
+- When `nnn` creates a GitHub issue via new-feature agent, **always provide the full URL**
+- User expectation: issue number alone is not enough - need clickable link
+- The new-feature agent reports success but link must be surfaced to user
+
+## How Things Connect
+- `nnn` workflow chain: context-finder (haiku) → Plan (haiku) → new-feature (sonnet)
+- new-feature agent creates issue via `gh issue create`
+- Agent returns issue number but **main agent must fetch and display URL**
+- Use `gh issue view N --json url --jq '.url'` to get link
+
+## Key Discoveries
+- Subagent output != user-facing output
+- Main agent responsible for presenting results with proper links
+- User feedback: "always give me the links" - direct, clear expectation
+
+## Workflow Fix
+After new-feature creates issue, always run:
+```bash
+gh issue view [NUMBER] --json url --jq '.url'
+```
+Then present: `**Issue #N**: [full URL]`
+
+## Tags
+`nnn` `workflow` `new-feature` `ux` `links` `user-feedback`
+
+## Raw Thoughts
+- Should this be baked into new-feature agent itself?
+- Or is it main agent's job to present results?
+- Either way: user sees number, wants link. Always provide both.


### PR DESCRIPTION
## Summary

Removed deprecated MAW (Multi-Agent Workflow) local infrastructure files that have been replaced by the modern agent workflow documented in CLAUDE_subagents.md. These were local development files not tracked in git, so cleanup involved:

- Deleted 6 prompt files from `.codex/prompts/` (untracked)
- Deleted 5 shell scripts from `.claude/commands/` (untracked)  
- Deleted 5 duplicate markdown files from `.claude/commands/` (untracked)
- Added deprecation notice to remaining maw.codex.md to guide users to modern workflow

## Files Removed

### From `.codex/prompts/` (untracked):
- `maw.agents-create.md`
- `maw.codex.md`
- `maw.hey.md`
- `maw.issue.md`
- `maw.sync.md`
- `maw.zoom.md`

### From `.claude/commands/` (untracked):
- `maw.agents-create.md`
- `maw.codex.sh`
- `maw.hey.md`
- `maw.hey.sh`
- `maw.issue.md`
- `maw.issue.sh`
- `maw.sync.md`
- `maw.sync.sh`
- `maw.zoom.md`
- `maw.zoom.sh`

## Notes

- `.codex/prompts/` directory still contains valid speckit.* files, so directory remains
- `.claude/commands/maw.codex.md` was left in place but documented as deprecated
- No tracked files were affected since MAW files were in .gitignore

## Test plan

- [x] Verified no tracked files were affected
- [x] Confirmed deleted files were untracked (in .gitignore)
- [x] Verified directory cleanup (only speckit files remain in .codex/prompts/)
- [x] Added clear deprecation notice to remaining maw.codex.md

🤖 Generated with Claude Code

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `nnn` workflow by ensuring that when a GitHub issue is created, the full URL is provided to the user, not just the issue number. This change is aimed at improving user experience and meeting user expectations for clear access to links.

### Detailed summary
- Added a section titled `nnn Workflow: Always Provide Links`.
- Emphasized the need to provide the full URL when creating GitHub issues.
- Clarified the workflow chain involving `context-finder`, `Plan`, and `new-feature`.
- Specified the command `gh issue view N --json url --jq '.url'` to fetch the issue link.
- Introduced a new workflow fix to always present both issue number and URL.
- Included user feedback highlighting the importance of providing links.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->